### PR TITLE
Adding ability to use NSColor instead of NSImage

### DIFF
--- a/source/MABNSSLider.swift
+++ b/source/MABNSSLider.swift
@@ -242,7 +242,31 @@ class MABSlider:NSSlider {
         let cell = self.cell as! MABSliderCell
         cell.barRightAgeImage = image
     }
+	
+	
+	func setBarFillColor(color: NSColor, size: Int) {
+		setBarFillImage(image: NSImage(color: color, size: NSSize(width: size, height: size)))
+	}
+	
+	func setKnobColor(color: NSColor, size: Int) {
+		setKnobImage(image: NSImage(color: color, size: NSSize(width: size, height: size)))
+	}
+	
+	func setBarFillBeforeKnobColor(color: NSColor, size: Int) {
+		setBarFillBeforeKnobImage(image: NSImage(color: color, size: NSSize(width: size, height: size)))
+	}
+	
+	
 }
 
+extension NSImage {
 
+	/// https://stackoverflow.com/a/40748898/6884062 by ben-leggiero
+    convenience init(color: NSColor, size: NSSize) {
+        self.init(size: size)
+        lockFocus()
+        color.drawSwatch(in: NSRect(origin: .zero, size: size))
+        unlockFocus()
+    }
+}
 

--- a/source/MABNSSLider.swift
+++ b/source/MABNSSLider.swift
@@ -256,6 +256,15 @@ class MABSlider:NSSlider {
 		setBarFillBeforeKnobImage(image: NSImage(color: color, size: NSSize(width: size, height: size)))
 	}
 	
+	func setBarRightAgeColor(color: NSColor, size: Int) {
+        let cell = self.cell as! MABSliderCell
+        cell.barRightAgeImage = NSImage(color: color, size: NSSize(width: size, height: size))
+    }
+	
+	func setBarLeftAgeColor(color: NSColor, size: Int) {
+        let cell = self.cell as! MABSliderCell
+        cell.barRightAgeImage = NSImage(color: color, size: NSSize(width: size, height: size))
+    }
 	
 }
 


### PR DESCRIPTION
As I usually use a solid color to fill the MABSlider I have to add an NSImage filled with that one color every time. This is a bit annoying.
Therefore I added a set of methods which accept a NSColor as parameter. A NSImage filled with that color is created and then the pre-existent methods are called to change the appearance of the MABSlider.